### PR TITLE
fix run error when run glm on gaudi1

### DIFF
--- a/configure_data.py
+++ b/configure_data.py
@@ -142,7 +142,8 @@ def prepare_tokenizer(args):
         token_counts = torch.LongTensor([after, eod_token]).to("hpu")
     else:
         # token_counts = torch.cuda.LongTensor([0, 0])
-        token_counts = torch.LongTensor([0, 0], device="hpu")
+        token_counts = torch.tensor([0, 0], device="hpu")
+        token_counts = token_counts.long()
     # Broadcast num tokens.
     torch.distributed.broadcast(token_counts,
                                 mpu.get_model_parallel_src_rank(),

--- a/generate_samples.py
+++ b/generate_samples.py
@@ -257,7 +257,7 @@ def generate_samples(model, tokenizer, args, device):
     if not os.path.exists(output_path):
         os.makedirs(output_path)
     output_path = os.path.join(output_path, f"sample-{datetime.now().strftime('%m-%d-%H-%M')}.txt")
-    with torch.no_grad(), open(output_path, "w") as output, torch.autocast("hpu", dtype=torch.float16, enabled=True):
+    with torch.no_grad(), open(output_path, "w") as output, torch.autocast("hpu", dtype=torch.bfloat16, enabled=True):
         while True:
             torch.distributed.barrier(group=mpu.get_model_parallel_group())
 

--- a/mpu/grads.py
+++ b/mpu/grads.py
@@ -19,7 +19,7 @@
 
 
 import torch
-from torch._six import inf
+from torch import inf
 
 from .initialize import get_model_parallel_group
 from .initialize import get_model_parallel_rank

--- a/scripts/generate_block.sh
+++ b/scripts/generate_block.sh
@@ -18,7 +18,7 @@ script_dir=$(dirname $script_path)
 
 config_json="$script_dir/ds_config.json"
 
-python -m torch.distributed.launch --nproc_per_node=$MPSIZE --master_port $MASTER_PORT generate_samples.py \
+python -m torch.distributed.run --nproc_per_node=$MPSIZE --master_port $MASTER_PORT generate_samples.py \
        --DDP-impl none \
        --model-parallel-size $MPSIZE \
        $MODEL_ARGS \

--- a/train_utils.py
+++ b/train_utils.py
@@ -30,7 +30,7 @@ def load_pretrained(model, checkpoint_path, args, task_tokens=None):
     if isinstance(model, FP16_Module):
         model = model.module
     if hasattr(model, "model"):
-        model = model.model
+        model = model.bfloat16()
 
     # Model.
     def extend_embedding_weights(state_weights, model_weights):


### PR DESCRIPTION
1.LongTensor does not take device parameter
2.--local-rank is not recognied arguments which is now deprecated,use
  run instread of launch
3.user bfloat16 for float16/half is not supported on Gaudi